### PR TITLE
Note Internal Group Creation step for TestFlight builders

### DIFF
--- a/docs/install/personal_testflight.md
+++ b/docs/install/personal_testflight.md
@@ -140,6 +140,8 @@ Make sure the app **xDrip4iOS** is selected and click on the **TestFlight** tab 
 
 <img src="../img/Picture15.png" style="zoom:50%;" />
 
+Click the blue plus ("**+**") symbol next to **Internal Testing** to add a new group.  You can name it however you like, for example 'App Store Connect Users'.  Click 'Create'.
+
 Click Internal Testing -> **App Store Connect Users**
 
 Click **+** to add a tester


### PR DESCRIPTION
Just a small change to note that a group must be manually created for new App Store Connect Users publishing to TestFlight.

(At least, that was my experience.  Perhaps this has changed since the document was produced, or perhaps it's different in different regions, but it seems to make sense.)